### PR TITLE
Remove wayland socket

### DIFF
--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -7,9 +7,8 @@ separate-locales: false
 
 finish-args:
         - --share=network
-        - --socket=fallback-x11
+        - --socket=x11
         - --share=ipc
-        - --socket=wayland
         - --device=dri
         - --allow=devel
         - --socket=pulseaudio


### PR DESCRIPTION
Roblox doesn't launch for me in KDE Wayland with the wayland socket enabled, I had to remove the wayland permissions to force it to run in Xwayland, then it worked.