### PR TITLE
Add device=all perms for controller support

### DIFF
--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -11,10 +11,10 @@ finish-args:
         - --share=ipc
         - --socket=wayland
         - --device=dri
-        - --allow=devel
+        - --allow=devel # Necessary for VMProtect to function.
         - --socket=pulseaudio
         - --allow=multiarch
-
+        - --device=all # Necessary for controller support (including on SteamDeck)
 add-extensions:
         org.freedesktop.Platform.Compat.i386:
                 directory: lib/i386-linux-gnu


### PR DESCRIPTION
Currently, the flatpak does not support the usage of controllers without enabling `device=all` through flatseal. This limitation makes it difficult for new SteamDeck and other controller users to have a seamless experience. However, enabling `device=all` would reduce the sandboxing of the flatpak. Please leave suggestions and opinions regarding this issue.