### PR TITLE
Update Grapejuice to 7.8.3

### DIFF
--- a/net.brinkervii.grapejuice.metainfo.xml
+++ b/net.brinkervii.grapejuice.metainfo.xml
@@ -27,12 +27,14 @@
 		</screenshot>
 	</screenshots>
 	<releases>
-		<release version="7.5.1" date="2023-1-29">
+		<release version="7.8.3" date="2023-02-19">
 			<description>
 				<p>A new release!</p>
 				<p>This version of Grapejuice brings:</p>
 				<ul>
-					<li>A fix to DXVK logic.</li>
+					<li>Replaced the Sign into Studio button with an App button</li>
+					<li>Made logging more verbose in Winprefix creation/search functions</li>
+					<li>Reduce possible [REDACTED] spam in logs</li>
 				</ul>
 			</description>
 		</release>

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -18,7 +18,7 @@ finish-args:
   - --allow=multiarch
   - --device=all # Necessary for controller support (important on Steam Deck)
 
-add-extensions:   
+add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
     version: '22.08'
@@ -75,6 +75,7 @@ modules:
     build-commands:
       # Install user_settings.json to preconfigure settings
       - install -Dm644 user_settings.json /app/user_settings_brinkerwine.json
+      - rm pyproject.toml
       # Run Grapejuice packaging module
       - PYTHONPATH=$(pwd)/src python3 -m grapejuice_packaging linux_package
       - cp -r build/linux_package/usr/* /app
@@ -122,8 +123,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/brinkervii/grapejuice.git
-        tag: v7.5.1
-        commit: d7577c65853c12ae6891ddb13988a8b8b486b0ee
+        tag: v7.8.3
+        commit: 605e381db171a07485a31edd38811be97618a614
       - type: patch
         path: brinker_wine.patch
       - type: patch

--- a/python3-requirements.yml
+++ b/python3-requirements.yml
@@ -71,11 +71,10 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/ef/81/14b3b8f01ddaddad6cdec97f2f599aa2fa466bd5ee9af99b08b7713ccd29/charset_normalizer-3.1.0-py3-none-any.whl
-        sha256: 3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d
+        url: https://files.pythonhosted.org/packages/ff/d7/8d757f8bd45be079d76309248845a04f09619a7b17d6dfc8c9ff6433cac2/charset-normalizer-3.1.0.tar.gz
+        sha256: 34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5
         x-checker-data:
-          name: charset_normalizer
-          packagetype: bdist_wheel
+          name: charset-normalizer
           type: pypi
       - type: file
         url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl

--- a/python3-requirements.yml
+++ b/python3-requirements.yml
@@ -130,8 +130,8 @@ modules:
         --prefix=${FLATPAK_DEST} "pydantic" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/8b/87/200171b36005368bc4c114f01cb9e8ae2a3f3325a47da8c710cc58cfd00c/pydantic-1.10.6.tar.gz
-        sha256: cf95adb0d1671fc38d8c43dd921ad5814a735e7d9b4d9e437c088002863854fd
+        url: https://files.pythonhosted.org/packages/43/5f/e53a850fd32dddefc998b6bfcbda843d4ff5b0dcac02a92e414ba6c97d46/pydantic-1.10.7.tar.gz
+        sha256: cfc83c0678b6ba51b0532bea66860617c4cd4251ecf76e9846fa5a9f3454e97e
         x-checker-data:
           name: pydantic
           type: pypi

--- a/python3-requirements.yml
+++ b/python3-requirements.yml
@@ -38,8 +38,8 @@ modules:
         --prefix=${FLATPAK_DEST} "PyGObject" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/07/73/a034fc1bcd6d402d6f72ff618c093f91ac6921f968cc19806b6a1b1b19c8/PyGObject-3.44.0.tar.gz
-        sha256: 34c21bdca7aeaa602980dc51c11bb31ec300753975a66d5d41cb67e619e6835b
+        url: https://files.pythonhosted.org/packages/44/80/96d6317a15a13a4f80ffa61118dc144a70756135fbc6ace30f9b033f51f7/PyGObject-3.44.1.tar.gz
+        sha256: 665fbe980c91e8b31ad78ed3f66879946948200864002d193f67eccc1d7d5d83
         x-checker-data:
           name: PyGObject
           type: pypi


### PR DESCRIPTION
I combined all changelogs between 7.6.2 and 7.8.3 (except changes that mention `pyproject.toml`, which we don't use).

Hope it's okay!

Closes #47 
Closes #49
Closes #50 
Closes #51