### PR TITLE
Update Wine to 7.20

### DIFF
--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -127,15 +127,24 @@ modules:
       - mv -v /app/share/applications/roblox-studio.desktop /app/share/applications/${FLATPAK_ID}.robloxstudio.desktop
       - mv -v /app/share/applications/roblox-studio-auth.desktop /app/share/applications/${FLATPAK_ID}.robloxstudioauth.desktop
       # Edit Grapejuice shortcut
-      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.desktop --set-icon=${FLATPAK_ID} --set-key=Exec --set-value='grapejuice gui'
+      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.desktop --set-icon=${FLATPAK_ID}
+        --set-key=Exec --set-value='grapejuice gui'
       # Edit Roblox App shortcut
-      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxapp.desktop --set-icon=${FLATPAK_ID}.robloxplayer --set-key=Exec --set-value='grapejuice app'
+      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxapp.desktop
+        --set-icon=${FLATPAK_ID}.robloxplayer --set-key=Exec --set-value='grapejuice
+        app'
       # Edit Roblox Player shortcut
-      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxplayer.desktop --set-icon=${FLATPAK_ID}.robloxplayer --set-key=Exec --set-value='grapejuice player %u'
+      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxplayer.desktop
+        --set-icon=${FLATPAK_ID}.robloxplayer --set-key=Exec --set-value='grapejuice
+        player %u'
       # Edit Roblox Studio shortcut
-      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxstudio.desktop --set-icon=${FLATPAK_ID}.robloxstudio --set-key=Exec --set-value='grapejuice studio %u'
+      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxstudio.desktop
+        --set-icon=${FLATPAK_ID}.robloxstudio --set-key=Exec --set-value='grapejuice
+        studio %u'
       # Edit Roblox Studio authentication shortcut
-      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxstudioauth.desktop --set-icon=${FLATPAK_ID}.robloxstudio --set-key=Exec --set-value='grapejuice studio-auth %u'
+      - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxstudioauth.desktop
+        --set-icon=${FLATPAK_ID}.robloxstudio --set-key=Exec --set-value='grapejuice
+        studio-auth %u'
       # Rename Grapejuice icons
       - |
         for res in 16x16 24x24 32x32 48x48 64x64 128x128 256x256
@@ -151,5 +160,9 @@ modules:
         url: https://gitlab.com/brinkervii/grapejuice.git
         tag: v7.8.3
         commit: 605e381db171a07485a31edd38811be97618a614
+        x-data-checker:
+          is-main-source: true
+          type: git
+          tag-pattern: ^v([\d.]+)$
       - type: file
         path: net.brinkervii.grapejuice.metainfo.xml

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -71,15 +71,24 @@ modules:
         path: ld.so.conf
 
   # put brinkerwine back in...this is going to annihilate studio performance, but people want it
-  - name: patched_wine
+  - name: wine-tkg
     buildsystem: simple
     build-commands:
       - mkdir -p /app/patched_wine
-      - tar -C /app/patched_wine --use-compress-program unzstd --strip-components 1 -xvf debuntu-wine-tkg-staging-fsync-git-*.tar.zst
+      - tar -C /app/patched_wine -I unzstd --strip-components 2 -xvf wine-tkg.tar.zst
+      - stat /app/patched_wine/bin/wine
     sources:
       - type: file
-        url: https://gitlab.com/brinkervii/wine-builds/-/raw/main/debuntu-wine-tkg-staging-fsync-git-7.1.r2.gc437a01e.tar.zst
-        sha256: 0e5ce9215b5e03d2fe2df3f54e75409c19af5e831c91613203bb1a33f7236bc1
+        dest-filename: wine-tkg.tar.zst
+        url: https://gitlab.com/brinkervii/wine-builds/-/raw/main/debuntu-wine-tkg-staging-fsync-git-7.20.r1.gbd2608b1.tar.zst
+        sha256: 1ee4e5a4ebc13ea172b14fc2c8088ed83e5436641c0a6411aa38ed31dda68581
+        x-checker-data:
+          type: json
+          url: https://gitlab.com/brinkervii/wine-builds/-/refs/main/logs_tree/?format=json&offset=0
+          version-query: last(.[] | select(.file_name | startswith("debuntu-wine-tkg-staging-fsync-git")))
+            | .file_name | capture("-git-(?<version>(.+?)).tar.zst$").version
+          url-query: last(.[] | select(.file_name | startswith("debuntu-wine-tkg-staging-fsync-git")))
+            | @uri "https://gitlab.com/brinkervii/wine-builds/-/raw/main/\(.file_name)"
 
   - name: glxinfo
     buildsystem: meson


### PR DESCRIPTION
Follow what the official, [upstream install script](https://pastebin.com/raw/5SeVb005) does (see the `use_version()` function).

I had to update `--strip-components` to `2` because this Wine package includes an extra, empty parent directory.

As we don't know if the next package will also contain this extra directory, I've added an extra command to ensure that the `wine` binary exists in `/app/patched_wine/bin` (if it doesn't, the CI will fail instead of just incorrectly succeed).