### PR TITLE
Fix iconless GUI

### DIFF
--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -147,7 +147,7 @@ modules:
               stable-only: true
               url-template: https://www.cabextract.org.uk/cabextract-$version.tar.gz
         cleanup:
-          - /man
+          - /share/man
 
       - name: p7zip
         no-autogen: true

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -215,12 +215,12 @@ modules:
       - |
         for res in 16x16 24x24 32x32 48x48 64x64 128x128 256x256
         do
-          mv -v /app/share/icons/hicolor/${res}/apps/grapejuice.png /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.png
-          mv -v /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-player.png /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxplayer.png
-          mv -v /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-studio.png /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxstudio.png
+          ln -rsv /app/share/icons/hicolor/${res}/apps/grapejuice.png -T /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.png
+          ln -rsv /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-player.png -T /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxplayer.png
+          ln -rsv /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-studio.png -T /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxstudio.png
         done
       # Scalable/vector icon
-      - mv -v /app/share/icons/hicolor/scalable/apps/grapejuice.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.png
+      - ln -rsv /app/share/icons/hicolor/scalable/apps/grapejuice.svg -T /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.png
     sources:
       - type: git
         url: https://gitlab.com/brinkervii/grapejuice.git


### PR DESCRIPTION
Grapejuice expects its icons to have specific names, and because we were renaming them to something else, the app wouldn't be able to find them, leaving users with an iconless GUI :(

![image](https://user-images.githubusercontent.com/626206/231714609-a76c7c96-0b12-4009-8a9c-7f625ab578b2.png)

A better approach is to symlink them instead, therefore keeping the original ones.