### PR TITLE
Grapejuice v7.14.4 & Replace old Wine build

### DIFF
--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,2 +1,0 @@
-/app/lib32
-/app/lib/i386-linux-gnu

--- a/net.brinkervii.grapejuice.metainfo.xml
+++ b/net.brinkervii.grapejuice.metainfo.xml
@@ -27,13 +27,15 @@
 		</screenshot>
 	</screenshots>
 	<releases>
-		<release version="7.8.11" date="2023-02-19">
+		<release version="7.14.4" date="2023-08-17">
 			<description>
-				<p>A new release!</p>
-				<p>This version of Grapejuice brings:</p>
+				<p>NOTE: Roblox is still broken!</p>
+				<p>This version of Grapejuice adds a Roblox Release channel setting!</p>
+				<p>Aside that some minor bugs were fixed:</p>
 				<ul>
-					<li>Roblox is still broken. Sorry folks, blame their anti-cheat...</li>
-					<li>Bugfixes</li>
+					<li>Grapejuice now throws a real error when it can not fetch a version</li>
+					<li>The self-updater doesn't crash anymore. This broke after the virtualenv update</li>
+					<li>Removed the player warning dialog</li>
 				</ul>
 			</description>
 		</release>

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -2,8 +2,6 @@ app-id: net.brinkervii.grapejuice
 runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
-sdk-extensions:
-  - org.freedesktop.Sdk.Extension.rust-stable
 command: grapejuice
 separate-locales: false
 
@@ -185,7 +183,7 @@ modules:
           - /man
           - /share
 
-  - python3-requirements.yml
+  - python3-requirements.yaml
 
   - name: grapejuice
     buildsystem: simple

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -105,7 +105,10 @@ modules:
     buildsystem: meson
     config-opts:
       - --bindir=/app/mesa-demos
+      - -Degl=disabled
       - -Dglut=disabled
+      - -Dosmesa=disabled
+      - -Dvulkan=disabled
       - -Dwayland=disabled
     post-install:
       - mv -v /app/mesa-demos/glxinfo /app/bin
@@ -121,7 +124,7 @@ modules:
     cleanup:
       - /include
       - /mesa-demos
-      - /share/mesa-demos
+      - /share
     modules:
       - shared-modules/glu/glu-9.json
 

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -81,25 +81,25 @@ modules:
           /app/lib32
           /app/lib/i386-linux-gnu
 
-  # put brinkerwine back in...this is going to annihilate studio performance, but people want it
-  - name: wine-tkg
+  - name: wine
     buildsystem: simple
     build-commands:
+      # NOTE: Users might have manually modified their PATH variable, so for backwards compatibility,
+      #       please always install Wine to /app/patched_wine to avoid breaking the app unnecessarily.
       - mkdir -p /app/patched_wine
-      - tar -C /app/patched_wine -I unzstd --strip-components 2 -xvf wine-tkg.tar.zst
+      - tar -C /app/patched_wine --strip-components 1 -xvf wine.tar.xz
       - stat /app/patched_wine/bin/wine
     sources:
       - type: file
-        dest-filename: wine-tkg.tar.zst
-        url: https://gitlab.com/brinkervii/wine-builds/-/raw/main/debuntu-wine-tkg-staging-fsync-git-7.20.r1.gbd2608b1.tar.zst
-        sha256: 1ee4e5a4ebc13ea172b14fc2c8088ed83e5436641c0a6411aa38ed31dda68581
+        dest-filename: wine.tar.xz
+        url: https://github.com/Kron4ek/Wine-Builds/releases/download/8.13/wine-8.13-staging-amd64.tar.xz
+        sha256: 95971fd97c1ca6dab218b0db256905faabd88c641dc8c8fadde9f9d14f0ada08
         x-checker-data:
           type: json
-          url: https://gitlab.com/brinkervii/wine-builds/-/refs/main/logs_tree/?format=json&offset=0
-          version-query: last(.[] | select(.file_name | startswith("debuntu-wine-tkg-staging-fsync-git")))
-            | .file_name | capture("-git-(?<version>(.+?)).tar.zst$").version
-          url-query: last(.[] | select(.file_name | startswith("debuntu-wine-tkg-staging-fsync-git")))
-            | @uri "https://gitlab.com/brinkervii/wine-builds/-/raw/main/\(.file_name)"
+          url: https://api.github.com/repos/Kron4ek/Wine-Builds/releases
+          version-query: first(.[] | select(.tag_name | test("^[0-9]"))).tag_name
+          url-query: .[] | select(.tag_name == "" + $version + "") | .assets[] | select(.name
+            == "wine-" + $version + "-staging-amd64.tar.xz").browser_download_url
 
   - name: glxinfo
     buildsystem: meson

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -233,13 +233,14 @@ modules:
         done
       - cp /app/share/icons/hicolor/scalable/apps/grapejuice.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.png
     sources:
-      - type: git
-        url: https://gitlab.com/brinkervii/grapejuice.git
-        tag: v7.11.4
-        commit: 33595fccf58e598907e9907a171368a3b4f976b5
-        x-data-checker:
-          is-main-source: true
-          type: git
-          tag-pattern: ^v([\d.]+)$
+      - type: archive
+        url: https://gitlab.com/brinkervii/grapejuice/-/archive/v7.14.4/grapejuice-v7.14.4.tar.bz2
+        sha256: a365793e486224a72ab321e49457ec6c7f994620350d2c2489bd87a4b0c593c4
+        x-checker-data:
+          type: json
+          url: https://gitlab.com/api/v4/projects/brinkervii%2Fgrapejuice/releases/permalink/latest
+          version-query: .tag_name
+          url-query: .assets.sources[] | select(.url | endswith("/grapejuice-" + $version
+            + ".tar.bz2")) | .url
       - type: file
         path: net.brinkervii.grapejuice.metainfo.xml

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -27,6 +27,11 @@ add-extensions:
     directory: lib/i386-linux-gnu
     version: '22.08'
 
+  org.freedesktop.Platform.Compat.i386.Debug:
+    directory: lib/debug/lib/i386-linux-gnu
+    version: '22.08'
+    no-autodownload: true
+
   org.freedesktop.Platform.GL32:
     directory: lib/i386-linux-gnu/GL
     version: '1.4'
@@ -65,12 +70,16 @@ modules:
   - name: bundle-setup
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/lib32
       - mkdir -p /app/lib/i386-linux-gnu
-      - install -Dm644 ld.so.conf -t /app/etc/
+      - mkdir -p /app/lib/debug/lib/i386-linux-gnu
+      - mkdir -p /app/lib/i386-linux-gnu/GL
+      - install -Dm644 ld.so.conf /app/etc/ld.so.conf
     sources:
-      - type: file
-        path: ld.so.conf
+      - type: inline
+        dest-filename: ld.so.conf
+        contents: |
+          /app/lib32
+          /app/lib/i386-linux-gnu
 
   # put brinkerwine back in...this is going to annihilate studio performance, but people want it
   - name: wine-tkg

--- a/net.brinkervii.grapejuice.yml
+++ b/net.brinkervii.grapejuice.yml
@@ -225,16 +225,15 @@ modules:
       - desktop-file-edit /app/share/applications/${FLATPAK_ID}.robloxstudioauth.desktop
         --set-icon=${FLATPAK_ID}.robloxstudio --set-key=Exec --set-value='grapejuice
         studio-auth %u'
-      # Rename Grapejuice icons
+      # Copy and rename Grapejuice icons so they can be properly exported by flatpak-builder.
       - |
         for res in 16x16 24x24 32x32 48x48 64x64 128x128 256x256
         do
-          ln -rsv /app/share/icons/hicolor/${res}/apps/grapejuice.png -T /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.png
-          ln -rsv /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-player.png -T /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxplayer.png
-          ln -rsv /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-studio.png -T /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxstudio.png
+          cp /app/share/icons/hicolor/${res}/apps/grapejuice.png /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.png
+          cp /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-player.png /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxplayer.png
+          cp /app/share/icons/hicolor/${res}/apps/grapejuice-roblox-studio.png /app/share/icons/hicolor/${res}/apps/${FLATPAK_ID}.robloxstudio.png
         done
-      # Scalable/vector icon
-      - ln -rsv /app/share/icons/hicolor/scalable/apps/grapejuice.svg -T /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.png
+      - cp /app/share/icons/hicolor/scalable/apps/grapejuice.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.png
     sources:
       - type: git
         url: https://gitlab.com/brinkervii/grapejuice.git

--- a/python3-requirements.yaml
+++ b/python3-requirements.yaml
@@ -1,7 +1,8 @@
 # To generate this file correctly using flatpak-pip-generator:
 # 1. Open 'requirements.txt', found in Grapejuice's root folder.
-# 2. Add 'pycairo', 'hatchling', 'setuptools-rust', 'maturin', and 'toml' at the very top.
-# 3. Save the file and run the command below:
+# 2. Add 'pycairo' at the very top.
+# 3. Replace 'pydantic' by 'pydantic<2'.
+# 4. Save the file and run the command below:
 #    flatpak-pip-generator --checker-data --output python3-requirements --requirements-file requirements.txt --runtime org.freedesktop.Sdk//22.08 --yaml
 build-commands: []
 buildsystem: simple
@@ -117,8 +118,8 @@ modules:
         --prefix=${FLATPAK_DEST} "Click" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/1a/70/e63223f8116931d365993d4a6b7ef653a4d920b41d03de7c59499962821f/click-8.1.6-py3-none-any.whl
-        sha256: fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5
+        url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
+        sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
         x-checker-data:
           name: click
           packagetype: bdist_wheel
@@ -127,14 +128,16 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "pydantic==1.10.11" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "pydantic<2" --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/cf/01/e8a380dc6e92a76113f034c58c9ffdbd115753e9b944ddf5d2dbe862f248/pydantic-1.10.11.tar.gz
-        sha256: f66d479cf7eb331372c470614be6511eae96f1f120344c25f3f9bb59fb1b5528
+        url: https://files.pythonhosted.org/packages/3b/9b/a7631bf35e55326fd74654fe6bd896478f47d65e97ca69e60ddb1b3823ee/pydantic-1.10.12.tar.gz
+        sha256: 0fe8a415cea8f340e7a9af9c54fc71a649b43e8ca3cc732986116b3cb135d303
         x-checker-data:
           name: pydantic
           type: pypi
+          versions:
+            <: '2'
       - type: file
         url: https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl
         sha256: 440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36


### PR DESCRIPTION
This updates Grapejuice to [v7.14.4](https://gitlab.com/brinkervii/grapejuice/-/releases/v7.14.4) and switches from the old, git-based data checker to a JSON-based one using GitLab's API, which should be more reliable for detecting future releases.

This also replaces the old Wine-Tkg build (v7.20) by a 'vanilla', Wine Staging build (v8.13) [provided by Kron4ek](https://github.com/Kron4ek/Wine-Builds).

Keep in mind that even after this upgrade, I still can't even get past the installer screen of Roblox/Studio on a clean prefix. Terminating the MSEdge process also terminates the installer with an error ("Wine is not supported").

Regardless of that, I still think this is an upgrade worth doing...

Before merging this though, it'd be good to get at least one confirmation that this major Wine upgrade won't break people's (working?) prefixes.

Closes #106
Closes #107 
Closes #108 
Closes #109